### PR TITLE
Fixup the gem definition so we can cut a new version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 pkg/**
 doc/**/*.html
 metasm/dynldr-*.so
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source 'https://rubygems.org' do
-  gemspec
-end
+source 'https://rubygems.org'
+gemspec
+

--- a/metasm.gemspec
+++ b/metasm.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
   s.homepage      = 'http://metasm.cr0.org'
   s.license       = 'LGPL-2.1'
 
-  s.add_development_dependency "bundler", "~> 1.7"
   s.add_development_dependency "rake"
   s.add_development_dependency "test-unit"
 end


### PR DESCRIPTION
Before:

```
bundle install
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies...
Could not find compatible versions

Because the current Bundler version (4.0.10) does not satisfy bundler ~> 1.7
  and Gemfile depends on bundler ~> 1.7,
  version solving has failed.

Your bundle requires a different version of Bundler than the one you're running.
Install the necessary version with `gem install bundler:1.17.3` and rerun bundler using `bundle _1.17.3_ install`
```

After:
```
bundle install
Source locally installed gems is ignoring #<Bundler::StubSpecification name=ed25519 version=1.3.0 platform=ruby> because it is missing extensions
Source locally installed gems is ignoring #<Bundler::StubSpecification name=debase version=3.0.12 platform=ruby> because it is missing extensions
Source locally installed gems is ignoring #<Bundler::StubSpecification name=bson version=5.0.2 platform=ruby> because it is missing extensions
Bundle complete! 3 Gemfile dependencies, 4 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
```